### PR TITLE
Disable indentation

### DIFF
--- a/indent/adblockfilter.vim
+++ b/indent/adblockfilter.vim
@@ -1,0 +1,16 @@
+" ============================================================================
+" Language:     Adblock-Filter
+" File:         indent/adblockfilter.vim
+" Author:       yous <yousbe@gmail.com>
+" URL:          https://github.com/mojako/adblock-filter.vim
+" Last Change:  2016-12-08
+" ============================================================================
+
+if exists('b:did_indent')
+    finish
+endif
+let b:did_indent = 1
+
+setlocal nocindent
+
+" vim: set et sts=4 sw=4 wrap:


### PR DESCRIPTION
When we `set cindent`, Vim confuses filter rules and C++ constructor initializations. This is minimal filter to reproduce wrong indentation.

```
[Adblock Plus 2.0]
example.com##table:nth-of-type(1):not([width])
```

After typing Enter, the cursor will point to

```
[Adblock Plus 2.0]
example.com##table:nth-of-type(1):not([width])
                                  |
```

See `:help cino-i`.

> Indent C++ base class declarations and constructor initializations, if they start in a new line (otherwise they are aligned at the right side of the ':'). (default 'shiftwidth').

The `indent/adblockfilter.vim` just set `nocindent`.